### PR TITLE
Fix REGEX to match the beginning of the string reminder

### DIFF
--- a/src/Parser/EmojiParser.php
+++ b/src/Parser/EmojiParser.php
@@ -47,7 +47,7 @@ class EmojiParser implements InlineParserInterface
         if (!$emoji) {
             $cursor->restoreState($previousState);
 
-	    return false;
+            return false;
         }
 
         $node = new Span($this->getTitle($handle));

--- a/src/Parser/EmojiParser.php
+++ b/src/Parser/EmojiParser.php
@@ -11,7 +11,7 @@ use League\CommonMark\InlineParserContext;
 
 class EmojiParser implements InlineParserInterface
 {
-    private const REGEX = '/:[_-a-zA-Z0-9]{2,}:/i';
+    private const REGEX = '/^:[_-a-zA-Z0-9]{2,}:/i';
 
     private $alternateMapping;
 
@@ -44,13 +44,14 @@ class EmojiParser implements InlineParserInterface
         }
 
         $emoji = $this->getEmoji($handle);
-        if ($emoji) {
-            $node = new Span($this->getTitle($handle));
-            $node->appendChild(new Text($emoji));
-        } else {
-            $node = new Text($handle);
+        if (!$emoji) {
+            $cursor->restoreState($previousState);
+
+	    return false;
         }
 
+        $node = new Span($this->getTitle($handle));
+        $node->appendChild(new Text($emoji));
         $inlineContext->getContainer()->appendChild($node);
 
         return true;


### PR DESCRIPTION
Fix REGEX to **match at the beginning** of the string reminder. The REGEX should not be greedy it must match exactly what it is looking for. Otherwise it must return False and return to the saved state.

If REGEX is greedy and match something wrong in the reminder it can not restore the Parser back and it sees no words skipped 
and puts back only a wrong match thus "swallowing" a part of matched string. 

So your commit f8b489791a1daf8c293fd68782cbdb1367c38628 was actually wrong the code it changed was OK.

